### PR TITLE
Prefer Ubuntu regular fonts over Roboto

### DIFF
--- a/src/gnome-shell/3.18/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.18/gnome-shell-dark-compact.css
@@ -86,7 +86,7 @@ Examples:
 }
 
 stage {
-  font-family: "M+ 1c", Roboto, Ubuntu, Cantarell, Sans-Serif;
+  font-family: "M+ 1c", Ubuntu, Roboto, Cantarell, Sans-Serif;
   font-size: 9.75pt;
   font-weight: 400;
   color: #bebebe;
@@ -1061,7 +1061,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 /* TOP BAR */
 #panel {
   background-color: #262626;
-  font-weight: bold;
+  /*font-weight: bold;*/
   height: 28px;
 }
 

--- a/src/gnome-shell/3.18/gnome-shell-dark.css
+++ b/src/gnome-shell/3.18/gnome-shell-dark.css
@@ -86,7 +86,7 @@ Examples:
 }
 
 stage {
-  font-family: "M+ 1c", Roboto, Ubuntu, Cantarell, Sans-Serif;
+  font-family: "M+ 1c", Ubuntu, Roboto, Cantarell, Sans-Serif;
   font-size: 10.5pt;
   font-weight: 400;
   color: #bebebe;
@@ -1061,7 +1061,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 /* TOP BAR */
 #panel {
   background-color: #262626;
-  font-weight: bold;
+  /*font-weight: bold;*/
   height: 32px;
 }
 

--- a/src/gnome-shell/3.18/sass/_common.scss
+++ b/src/gnome-shell/3.18/sass/_common.scss
@@ -833,7 +833,7 @@ StScrollBar {
 
 #panel {
   background-color: $panel_bg_color;
-  font-weight: bold;
+  /*font-weight: bold;*/
   height: $menuitem_size;
 
   &:overview,

--- a/src/gnome-shell/3.18/sass/_variables.scss
+++ b/src/gnome-shell/3.18/sass/_variables.scss
@@ -4,8 +4,8 @@ $extra_background_clip: if($variant == 'light', padding-box, border-box);
 $panel-corner-radius: 0;
 
 // font families
-$font-family: "M+ 1c", Roboto, Ubuntu, Cantarell, Sans-Serif;
-$large-font-family: Roboto, "M+ 1c", Ubuntu, Cantarell, Sans-Serif;
+$font-family: "M+ 1c", Ubuntu, Roboto, Cantarell, Sans-Serif;
+$large-font-family: "M+ 1c", Ubuntu, Roboto,  Cantarell, Sans-Serif;
 
 // font sizes
 $root-font-size: if($compact == 'false', 14px, 13px);

--- a/src/gnome-shell/3.24/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.24/gnome-shell-dark-compact.css
@@ -86,7 +86,7 @@ Examples:
 }
 
 stage {
-  font-family: "M+ 1c", Roboto, Ubuntu, Cantarell, Sans-Serif;
+  font-family: "M+ 1c", Ubuntu, Roboto, Cantarell, Sans-Serif;
   font-size: 9.75pt;
   font-weight: 400;
   color: #bebebe;
@@ -1069,7 +1069,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 /* TOP BAR */
 #panel {
   background-color: #262626;
-  font-weight: bold;
+  /*font-weight: bold;*/
   height: 28px;
 }
 

--- a/src/gnome-shell/3.24/gnome-shell-dark.css
+++ b/src/gnome-shell/3.24/gnome-shell-dark.css
@@ -86,7 +86,7 @@ Examples:
 }
 
 stage {
-  font-family: "M+ 1c", Roboto, Ubuntu, Cantarell, Sans-Serif;
+  font-family: "M+ 1c", Ubuntu, Roboto, Cantarell, Sans-Serif;
   font-size: 10.5pt;
   font-weight: 400;
   color: #bebebe;
@@ -1069,7 +1069,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 /* TOP BAR */
 #panel {
   background-color: #262626;
-  font-weight: bold;
+  /*font-weight: bold;*/
   height: 32px;
 }
 

--- a/src/gnome-shell/3.24/sass/_common.scss
+++ b/src/gnome-shell/3.24/sass/_common.scss
@@ -836,7 +836,7 @@ StScrollBar {
 
 #panel {
   background-color: $panel_bg_color;
-  font-weight: bold;
+  /*font-weight: bold;*/
   height: $menuitem_size;
 
   &:overview,

--- a/src/gnome-shell/3.26/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.26/gnome-shell-dark-compact.css
@@ -86,7 +86,7 @@ Examples:
 }
 
 stage {
-  font-family: "M+ 1c", Roboto, Ubuntu, Cantarell, Sans-Serif;
+  font-family: "M+ 1c", Ubuntu, Roboto, Cantarell, Sans-Serif;
   font-size: 9.75pt;
   font-weight: 400;
   color: #bebebe;
@@ -1058,7 +1058,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   background-color: rgba(0, 0, 0, 0.6);
   /* transition from solid to transparent */
   transition-duration: 250ms;
-  font-weight: bold;
+  /*font-weight: bold;*/
   height: 28px;
 }
 

--- a/src/gnome-shell/3.26/gnome-shell-dark.css
+++ b/src/gnome-shell/3.26/gnome-shell-dark.css
@@ -86,7 +86,7 @@ Examples:
 }
 
 stage {
-  font-family: "M+ 1c", Roboto, Ubuntu, Cantarell, Sans-Serif;
+  font-family: "M+ 1c", Ubuntu, Roboto, Cantarell, Sans-Serif;
   font-size: 10.5pt;
   font-weight: 400;
   color: #bebebe;
@@ -1058,7 +1058,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   background-color: rgba(0, 0, 0, 0.6);
   /* transition from solid to transparent */
   transition-duration: 250ms;
-  font-weight: bold;
+  /*font-weight: bold;*/
   height: 32px;
 }
 

--- a/src/gnome-shell/3.26/sass/_common.scss
+++ b/src/gnome-shell/3.26/sass/_common.scss
@@ -811,7 +811,7 @@ StScrollBar {
   background-color: $bg_color;
   /* transition from solid to transparent */
   transition-duration: 250ms;
-  font-weight: bold;
+  /*font-weight: bold;*/
   height: $menuitem_size;
 
   &:overview,


### PR DESCRIPTION
If Roboto fonts are installed, they are used in gnome-shell theme instead of Ubuntu. I assumed that from the screenshots Ubuntu is preferred (?), things look more consistent with Ubuntu Regular fonts.
